### PR TITLE
feat(bar-auth): requireBarAuth-Middleware + Getränkepflege nur für Bar

### DIFF
--- a/public/bar.html
+++ b/public/bar.html
@@ -72,8 +72,19 @@
       <span id="drinks-arrow">▼</span>
     </div>
     <div class="bar-controls-body hidden" id="drinks-body" style="flex-direction:column;gap:.75rem;">
+      <div class="flex gap-1 flex-wrap" style="align-items:flex-end;">
+        <div class="form-group" style="flex:1;min-width:140px;margin-bottom:0;">
+          <label class="label" for="bar-new-drink-name">Neues Getränk</label>
+          <input class="input" type="text" id="bar-new-drink-name" placeholder="z. B. Moscow Mule" maxlength="60" autocomplete="off">
+        </div>
+        <div class="form-group" style="width:140px;margin-bottom:0;">
+          <label class="label" for="bar-new-drink-category">Kategorie</label>
+          <select class="select" id="bar-new-drink-category"></select>
+        </div>
+        <button type="button" class="btn btn-secondary" id="bar-btn-add-drink">Hinzufügen</button>
+      </div>
       <div id="drinks-list" style="display:flex;flex-wrap:wrap;gap:.5rem;"></div>
-      <p id="no-drinks-msg" class="text-muted hidden">Noch keine Getränke. Gäste können über "Add Drink" neue hinzufügen.</p>
+      <p id="no-drinks-msg" class="text-muted hidden">Noch keine Getränke – oben eintragen.</p>
     </div>
   </div>
 

--- a/public/guest.html
+++ b/public/guest.html
@@ -87,48 +87,22 @@
     </div>
 
     <div class="tabs" id="order-tabs">
-      <button class="tab active" data-tab="menu">Menu</button>
-      <button class="tab" data-tab="add-drink">Add Drink</button>
-      <button class="tab" data-tab="free-text">Free Text</button>
-      <button class="tab" data-tab="edit-drink">Edit Drink</button>
+      <button type="button" class="tab active" data-tab="menu">Menü</button>
+      <button type="button" class="tab" data-tab="free-text">Freie Bestellung</button>
     </div>
 
-    <!-- Tab: Menu -->
+    <!-- Tab: Menu (vom Bar-Modus gepflegt) -->
     <div id="tab-menu">
       <div id="drink-menu"></div>
     </div>
 
-    <!-- Tab: Add Drink -->
-    <div id="tab-add-drink" class="hidden">
-      <div class="form-group">
-        <label class="label" for="new-drink-name">Drink name</label>
-        <input class="input" type="text" id="new-drink-name" placeholder="e.g. Bionade Ingwer" maxlength="60" autocomplete="off">
-      </div>
-      <div class="form-group">
-        <label class="label" for="new-drink-category">Category</label>
-        <select class="select" id="new-drink-category">
-          <option value="soft">Soft Drink</option>
-          <option value="energy">Energy</option>
-          <option value="beer">Beer</option>
-          <option value="cocktail">Cocktail</option>
-          <option value="other">Other</option>
-        </select>
-      </div>
-      <button class="btn btn-secondary btn-full" id="btn-add-drink">Add to Menu & Select</button>
-    </div>
-
-    <!-- Tab: Edit Drink -->
-    <div id="tab-edit-drink" class="hidden">
-      <div id="edit-drink-list"></div>
-    </div>
-
-    <!-- Tab: Free Text -->
+    <!-- Tab: Freie Bestellung (nicht im Menü; z. B. Wasser mit Eis) -->
     <div id="tab-free-text" class="hidden">
       <div class="form-group">
-        <label class="label" for="free-text-input">Describe your order</label>
-        <input class="input" type="text" id="free-text-input" placeholder="e.g. A glass of water with ice" maxlength="100" autocomplete="off">
+        <label class="label" for="free-text-input">Was darf es sein?</label>
+        <input class="input" type="text" id="free-text-input" placeholder="z. B. Wasser mit Eis" maxlength="100" autocomplete="off">
       </div>
-      <p class="text-muted">This won't be added to the menu.</p>
+      <p class="text-muted">Landet als eigene Position im Warenkorb, nicht im Menü.</p>
     </div>
 
     <div class="card mt-2" style="background: var(--color-bg);">

--- a/public/js/pages/bar.js
+++ b/public/js/pages/bar.js
@@ -4,6 +4,13 @@
   const { escapeHtml, formatRelativeTime, formatElapsed } = Utils;
   const socket = SocketClient.getSocket();
 
+  function authJsonHeaders() {
+    const headers = { 'Content-Type': 'application/json' };
+    const token = window.Auth && Auth.getToken ? Auth.getToken() : null;
+    if (token) headers.Authorization = `Bearer ${token}`;
+    return headers;
+  }
+
   let orders = [];
   let timerInterval = null;
 
@@ -33,6 +40,42 @@
     ).join('');
   }
 
+  (function setupBarAddDrink() {
+    const catSelect = document.getElementById('bar-new-drink-category');
+    if (catSelect) {
+      catSelect.innerHTML = CATEGORIES.map(c =>
+        `<option value="${escapeHtml(c.value)}">${escapeHtml(c.label)}</option>`
+      ).join('');
+    }
+    const nameEl = document.getElementById('bar-new-drink-name');
+    const addBtn = document.getElementById('bar-btn-add-drink');
+    if (!addBtn || !nameEl) return;
+
+    async function submitNewDrink() {
+      const catEl = document.getElementById('bar-new-drink-category');
+      const name = nameEl.value.trim();
+      if (!name) { nameEl.focus(); return; }
+      try {
+        const res = await fetch('/api/drinks', {
+          method: 'POST',
+          headers: authJsonHeaders(),
+          body: JSON.stringify({ name, category: catEl.value }),
+        });
+        if (res.ok) {
+          nameEl.value = '';
+          await loadDrinks();
+        } else if (res.status === 401) {
+          alert('Nicht angemeldet – Seite neu laden und Passwort eingeben.');
+        }
+      } catch (err) { console.error(err); }
+    }
+
+    addBtn.addEventListener('click', submitNewDrink);
+    nameEl.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); submitNewDrink(); }
+    });
+  })();
+
   function renderDrinks(drinks) {
     const list = document.getElementById('drinks-list');
     const noMsg = document.getElementById('no-drinks-msg');
@@ -54,7 +97,7 @@
       sel.addEventListener('change', async () => {
         await fetch(`/api/drinks/${sel.dataset.catDrink}`, {
           method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
+          headers: authJsonHeaders(),
           body: JSON.stringify({ category: sel.value }),
         });
       });
@@ -62,7 +105,10 @@
     list.querySelectorAll('[data-delete-drink]').forEach(btn => {
       btn.addEventListener('click', async () => {
         if (!confirm(`Drink "${btn.closest('div').querySelector('span').textContent}" löschen?`)) return;
-        await fetch(`/api/drinks/${btn.dataset.deleteDrink}`, { method: 'DELETE' });
+        await fetch(`/api/drinks/${btn.dataset.deleteDrink}`, {
+          method: 'DELETE',
+          headers: authJsonHeaders(),
+        });
         await loadDrinks();
       });
     });

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -35,6 +35,26 @@ async function broadcastStats() {
   _io.emit(SOCKET_EVENTS.STATS_UPDATED, { stats });
 }
 
+function verifyBarToken(req) {
+  const auth = req.headers.authorization;
+  if (!auth || !auth.startsWith('Bearer ')) return false;
+  const token = auth.slice(7);
+  try {
+    const decoded = Buffer.from(token, 'base64').toString('utf8');
+    const password = decoded.split(':')[0];
+    return password === config.password;
+  } catch {
+    return false;
+  }
+}
+
+function requireBarAuth(req, res, next) {
+  if (!verifyBarToken(req)) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  next();
+}
+
 // --- Auth ---
 router.post('/auth', (req, res) => {
   const { password } = req.body;
@@ -78,7 +98,7 @@ router.get('/drinks', async (req, res) => {
   }
 });
 
-router.post('/drinks', async (req, res) => {
+router.post('/drinks', requireBarAuth, async (req, res) => {
   const { name, category } = req.body;
   if (!name || !name.trim()) return res.status(400).json({ error: 'Name required' });
   try {
@@ -89,7 +109,7 @@ router.post('/drinks', async (req, res) => {
   }
 });
 
-router.patch('/drinks/:id', async (req, res) => {
+router.patch('/drinks/:id', requireBarAuth, async (req, res) => {
   try {
     const drink = await updateDrink(req.params.id, req.body);
     if (!drink) return res.status(404).json({ error: 'Drink not found' });
@@ -99,7 +119,7 @@ router.patch('/drinks/:id', async (req, res) => {
   }
 });
 
-router.delete('/drinks/:id', async (req, res) => {
+router.delete('/drinks/:id', requireBarAuth, async (req, res) => {
   try {
     const ok = await deleteDrink(req.params.id);
     if (!ok) return res.status(404).json({ error: 'Drink not found' });


### PR DESCRIPTION
## Was & Warum

Bisher konnten Gäste Getränke zum Menü hinzufügen und bearbeiten – das war eine offene Schwachstelle. Dieser PR sichert alle schreibenden Drink-Endpunkte mit einer Bearer-Token-Middleware ab und verschiebt die Menüpflege ausschließlich in den Bar-Modus.

## Änderungen

### Server
- `verifyBarToken()` / `requireBarAuth` Middleware in `server/routes/api.js`
- `POST /api/drinks`, `PATCH /api/drinks/:id`, `DELETE /api/drinks/:id` erfordern jetzt ein gültiges Bar-Bearer-Token

### Bar-UI (`public/bar.html`, `public/js/pages/bar.js`)
- Neues Formular zum Hinzufügen von Getränken (Name + Kategorie) direkt in der Getränkeliste
- `authJsonHeaders()` Helper sendet den gespeicherten Token bei allen schreibenden Drink-Requests mit
- 401-Fehler wird dem Nutzer als klare Fehlermeldung angezeigt

### Gast-UI (`public/guest.html`)
- „Add Drink"- und „Edit Drink"-Tabs entfernt (Funktionalität jetzt ausschließlich im Bar-Modus)
- Verbleibende Tabs umbenannt: Menu → Menü, Free Text → Freie Bestellung

## Sicherheitskonzept

Das Token ist `base64(password:timestamp)`. Es ist kein kryptografisch starkes Auth-System, aber ausreichend für ein LAN-Party-Szenario mit bekannten Teilnehmern.

## Testen

1. Bar-Modus öffnen → Getränk hinzufügen, Kategorie ändern, Getränk löschen ✓
2. API direkt ohne Token aufrufen: `POST /api/drinks` → 401 erwartet
3. Gast-Modus öffnen → Nur noch „Menü" und „Freie Bestellung" als Tabs ✓

## Stack

Baut auf #12 auf. Merge-Reihenfolge einhalten.

```
   1. i18n/ui-texts        ✓ #12
➡ 2. feat/bar-auth         ← dieser PR
   3. feat/profanity-filter
   4. feat/cart-multi-item
```